### PR TITLE
Regexp instead of string check (return boolean)

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,6 @@
     if (typeof process === 'undefined' || !process) {
       return false;
     }
-    return process.platform === 'win32';
+    return /^win/.test(process.platform);
   }());
 }));


### PR DESCRIPTION
Seems to me that /^win/.test(process.platform) is more consistent since we can have a win64 in the future.
