### PR TITLE
export function instead of value also for AMD

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,20 +5,20 @@
     define(factory);
   } else if (typeof exports === 'object') {
     // Node.js
-    module.exports = factory;
+    module.exports = factory();
   } else {
     // Browser
-    root.isWindows = factory;
+    root.isWindows = factory();
   }
 }(this, function() {
   'use strict';
 
-  return (function isWindows() {
+  return function isWindows() {
     if (typeof process === 'undefined' || !process) {
       return false;
     }
     return process.platform === 'win32' ||
     process.env.OSTYPE === 'cygwin' ||
     process.env.OSTYPE === 'msys';
-  }());
+  };
 }));


### PR DESCRIPTION
AMD export doesn't work,`false/true` is returned instead of function. `define()` should get factory function which should return module itself (`isWindows` function in this case). 

Invoking factory function only when exporting for Common.js or Browser environments should be used instead of IIFE.

Proposed change is compatible with http://ifandelse.com/its-not-hard-making-your-library-support-amd-and-commonjs which looks like an inspiration of your solution.